### PR TITLE
Add logging for libeep failures and improve code formatting

### DIFF
--- a/python/libeep/cnt_reader.py
+++ b/python/libeep/cnt_reader.py
@@ -141,8 +141,8 @@ class CntReader:
 
         returns
         info: Tuple[str, int, int, Any, Any, Any]
-            information about this trigger in tehe following format
-            (markertype, sample_index, markervalue, Any, Any, Any)
+            information about this trigger in the following format
+            (marker_type, sample_index, marker_value, Any, Any, Any)
         """
         tc = self.get_trigger_count()
         if index < 0:

--- a/python/libeep/cnt_reader.py
+++ b/python/libeep/cnt_reader.py
@@ -144,14 +144,13 @@ class CntReader:
             information about this trigger in the following format
             (marker_type, sample_index, marker_value, Any, Any, Any)
         """
-        tc = self.get_trigger_count()
         if index < 0:
             raise IndexError(
                 f"{index} is smaller zero. Only positive indices are allowed"
             )
 
-        if index > tc or tc == 0:
-            raise IndexError(f"{index} larger than trigger count of {tc}")
+        if index >= self.get_trigger_count():
+            raise IndexError(f"{index=} is larger {self.get_trigger_count()=}")
         with self as f:
             info = pyeep.get_trigger(f._handle, index)
         return info

--- a/python/libeep/cnt_reader.py
+++ b/python/libeep/cnt_reader.py
@@ -108,7 +108,7 @@ class CntReader:
         Example
         -------
 
-        data = cnt.get_samples(0,1)
+        data = cnt.get_samples(0, 1)
         # return the first sample for all channels
 
         """

--- a/python/libeep/pyeep.c
+++ b/python/libeep/pyeep.c
@@ -158,12 +158,14 @@ pyeep_get_samples(PyObject *self, PyObject *args)
 
   if (!PyArg_ParseTuple(args, "iii", &handle, &fro, &to))
   {
+    fprintf(stderr, "pyeep_get_samples: PyArg_ParseTuple failed\n");
     return NULL;
   }
 
   float *libeep_sample_data = libeep_get_samples(handle, fro, to);
   if (libeep_sample_data == NULL)
   {
+    fprintf(stderr, "pyeep_get_samples: libeep_get_samples failed\n");
     return NULL;
   }
 
@@ -171,6 +173,7 @@ pyeep_get_samples(PyObject *self, PyObject *args)
   PyObject *python_list = PyList_New(array_len);
   if (!python_list)
   {
+    fprintf(stderr, "pyeep_get_samples: PyList_New failed\n");
     return NULL;
   }
   for (i = 0; i < array_len; i++)
@@ -179,6 +182,7 @@ pyeep_get_samples(PyObject *self, PyObject *args)
     if (!num)
     {
       Py_DECREF(python_list);
+      fprintf(stderr, "pyeep_get_samples: PyFloat_FromDouble failed\n");
       return NULL;
     }
     PyList_SET_ITEM(python_list, i, num); // reference to num stolen


### PR DESCRIPTION
Introduce logging for failures in the libeep functions to aid in debugging. Update variable names to follow snake_case conventions and fix an off-by-one error in the trigger retrieval logic.